### PR TITLE
初期読み込みの時間を減らすためにrequireの場所を変えた

### DIFF
--- a/lib/define.js
+++ b/lib/define.js
@@ -11,7 +11,6 @@
  */
 'use strict'
 
-const babel = require('babel-core')
 const { byPattern } = require('pon-task-compile')
 
 /** @lends define */
@@ -24,6 +23,7 @@ function define (srcDir, destDir, options = {}) {
   } = options
 
   const compiler = (code, inputSourceMap = null) => {
+    const babel = require('babel-core') // Require here to reduce initial loading time
     let compiled = babel.transform(code, {
       presets,
       sourceMaps,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * React compile task for pon
  * @module pon-task-react
- * @version 1.0.6
+ * @version 1.0.7
  */
 
 'use strict'

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   },
   "homepage": "https://github.com/realglobe-Inc/pon-task-react#readme",
   "dependencies": {
-    "babel-core": "^6.24.0",
-    "babel-preset-es2015": "^6.24.0",
-    "babel-preset-react": "^6.23.0",
+    "babel-core": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
     "co": "^4.6.0",
     "pon-task-compile": "^1.1.1"
   },
@@ -45,7 +45,7 @@
     "injectmock": "^2.0.0",
     "pon-context": "^1.1.4",
     "pon-doc": "^1.0.1",
-    "react": "^15.4.2",
+    "react": "^15.5.3",
     "sg-templates": "^1.4.4",
     "sugos-travis": "^2.0.7",
     "writeout": "^2.1.0"

--- a/test/define_test.js
+++ b/test/define_test.js
@@ -13,7 +13,7 @@ const writeout = require('writeout')
 const co = require('co')
 
 describe('define', function () {
-  this.timeout(3000)
+  this.timeout(5000)
 
   before(() => co(function * () {
 


### PR DESCRIPTION
fileの先頭でrequireするとこのtaskを実行しない場合でも全ての依存関係をロードしてしまい、無駄な時間がかかる。実行時に初めてrequireするように場所を変えた。