### PR TITLE
WatchTargetsオプションを追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Define task
 | options.presets | string[] |  Babel preset names |
 | options.extractCss | string |  Path to extract css |
 | options.plugins | string[] |  Babel plugin names |
+| options.watchTargets | string[] |  Additional watch target filenames |
 | options.watchDelay | number |  Delay after watch |
 
 

--- a/lib/define.js
+++ b/lib/define.js
@@ -8,6 +8,7 @@
  * @param {string[]} [options.presets=['es2015', 'es2016', 'es2017', 'react']] - Babel preset names
  * @param {string} [options.extractCss] - Path to extract css
  * @param {string[]} [options.plugins=['css-modules-transform']] - Babel plugin names
+ * @param {string[]} [options.watchTargets=[]] - Additional watch target filenames
  * @param {number} [options.watchDelay=100] - Delay after watch
  * @returns {function} Defined task
  */
@@ -22,6 +23,7 @@ function define (srcDir, destDir, options = {}) {
     pattern = [ '**/*.jsx', '**/*.js' ],
     presets = [ 'es2015', 'es2016', 'es2017', 'react' ],
     extractCss,
+    watchTargets = [],
     plugins = [ buildinPlugins.cssModules({ extractCss }) ],
     sourceMaps = 'inline',
     sourceRoot = srcDir,
@@ -45,6 +47,7 @@ function define (srcDir, destDir, options = {}) {
   let task = byPattern(srcDir, destDir, compiler, {
     pattern,
     watchDelay,
+    watchTargets,
     namer: (filename) => filename.replace(/\.jsx$/, '.js')
   })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * React compile task for pon
  * @module pon-task-react
- * @version 1.1.3
+ * @version 1.1.4
  */
 
 'use strict'

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-preset-es2017": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "co": "^4.6.0",
-    "pon-task-compile": "^2.0.1"
+    "pon-task-compile": "^2.1.5"
   },
   "devDependencies": {
     "ababel": "^2.0.1",
@@ -42,16 +42,16 @@
     "ape-releasing": "^4.0.4",
     "ape-tasking": "^4.0.9",
     "ape-tmpl": "^5.0.20",
-    "ape-updating": "^4.1.0",
+    "ape-updating": "^4.1.1",
     "asleep": "^1.0.3",
     "coz": "^6.0.20",
     "injectmock": "^2.0.0",
-    "pon-context": "^2.0.1",
+    "pon-context": "^2.0.2",
     "pon-doc": "^2.0.1",
     "react": "^15.5.4",
     "sg-templates": "^1.4.4",
     "sugos-travis": "^2.0.7",
-    "writeout": "^2.1.0"
+    "writeout": "^2.2.0"
   },
   "engines": {
     "node": ">=6",


### PR DESCRIPTION
Reactのコンパイル時にcss-modulesも解決する仕様になったので、watchの仕様も改造できるようにした。pcssの変更を見てコンパイルを発火できるようにする必要がある