### PR TITLE
NODE_ENV=developmentじゃないときにwarningを出すようにした

### DIFF
--- a/lib/define.js
+++ b/lib/define.js
@@ -55,7 +55,20 @@ function define (srcDir, destDir, options = {}) {
 
   return Object.assign(function react (ctx) {
     return task(ctx)
-  }, { watch })
+  }, {
+    watch: function watchDecorate (ctx) {
+      const { logger } = ctx
+      // Env check
+      {
+        const wanted = 'development'
+        const actual = process.env.NODE_ENV
+        if (wanted !== actual) {
+          logger.warn(`NODE_ENV should be one of "${wanted}", but given: "${actual}"`)
+        }
+      }
+      return watch.apply(this, arguments)
+    }
+  })
 }
 
 module.exports = define

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * React compile task for pon
  * @module pon-task-react
- * @version 1.1.5
+ * @version 1.1.6
  */
 
 'use strict'


### PR DESCRIPTION
developmentモードの時しかwatchがちゃんと走らないというわかりにくい挙動になってしまったので、そうじゃない時は警告で教えるようにした

https://github.com/realglobe-Inc/pon-task-react/issues/12